### PR TITLE
Added a config parameter `redirect_url`.

### DIFF
--- a/src/Cloudoki/OaStack/Controllers/OaStackViewController.php
+++ b/src/Cloudoki/OaStack/Controllers/OaStackViewController.php
@@ -142,7 +142,11 @@ class OaStackViewController extends BaseController {
 
 			return view('oastack::oauth2.reset', ['error'=> $reset->message]);
 
-		return redirect()->away(config('oastack.redirect_url'));
+		if (config('oastack.redirect_url'))
+
+			return redirect()->away(config('oastack.redirect_url'));
+
+		return redirect()->route('login');
 	}
 
 	/**

--- a/src/Cloudoki/OaStack/Controllers/OaStackViewController.php
+++ b/src/Cloudoki/OaStack/Controllers/OaStackViewController.php
@@ -142,7 +142,7 @@ class OaStackViewController extends BaseController {
 
 			return view('oastack::oauth2.reset', ['error'=> $reset->message]);
 
-		return redirect()->route('login');
+		return redirect()->away(config('oastack.redirect_url'));
 	}
 
 	/**

--- a/src/Cloudoki/OaStack/Views/oauth2/subscribed.blade.php
+++ b/src/Cloudoki/OaStack/Views/oauth2/subscribed.blade.php
@@ -30,9 +30,15 @@
 	@else
 		
 		<p>{{ trans('oastack::oauth2.user.subscribed.info', ['account'=> $name]) }}</p>
-		
-		<a class="btn btn-default" href='{{ Config::get ('oastack.redirect_url') }}'>{{ trans('oastack::oauth2.user.subscribed.proceed') }}</a>
-		
+
+		@if ( empty ( Config::get ('oastack.redirect_url' ) ) )
+
+			<a class="btn btn-default" href='{{ Config::get ('oastack.redirect_url') }}'>{{ trans('oastack::oauth2.user.subscribed.proceed') }}</a>
+
+		@else
+
+			<a class="btn btn-default" href='{{ Config::get ('app.url') }}'>{{ trans('oastack::oauth2.user.subscribed.proceed') }}</a>
+
 	@endif
 	
 	</div>

--- a/src/Cloudoki/OaStack/Views/oauth2/subscribed.blade.php
+++ b/src/Cloudoki/OaStack/Views/oauth2/subscribed.blade.php
@@ -31,7 +31,7 @@
 		
 		<p>{{ trans('oastack::oauth2.user.subscribed.info', ['account'=> $name]) }}</p>
 		
-		<a class="btn btn-default" href='{{ Config::get ('app.url') }}'>{{ trans('oastack::oauth2.user.subscribed.proceed') }}</a>
+		<a class="btn btn-default" href='{{ Config::get ('oastack.redirect_url') }}'>{{ trans('oastack::oauth2.user.subscribed.proceed') }}</a>
 		
 	@endif
 	

--- a/src/config/oastack.php
+++ b/src/config/oastack.php
@@ -14,5 +14,6 @@ return array(
 	
 	'invite_url' => 'http://localhost/oauth2/invitation',
 	'reset_url' =>  'http://localhost/oauth2/reset',
-	'privacy_url' => 'http://en.wikipedia.org/wiki/Privacy_policy'
+	'privacy_url' => 'http://en.wikipedia.org/wiki/Privacy_policy',
+	'redirect_url' => 'http://localhost/'
 );

--- a/src/config/oastack.php
+++ b/src/config/oastack.php
@@ -15,5 +15,8 @@ return array(
 	'invite_url' => 'http://localhost/oauth2/invitation',
 	'reset_url' =>  'http://localhost/oauth2/reset',
 	'privacy_url' => 'http://en.wikipedia.org/wiki/Privacy_policy',
-	'redirect_url' => 'http://localhost/'
+	/*
+	 * The URL to which users should be redirected after resetting their password
+	 */
+	'redirect_url' => ''
 );


### PR DESCRIPTION
This way we can redirect to the parent app's login URL in the password reset and invitation pages.